### PR TITLE
release: app-2.12.0

### DIFF
--- a/charts/app/Chart.yaml
+++ b/charts/app/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: app
 description: A Helm chart for Prosperi Applications
 type: application
-version: 2.11.1
+version: 2.12.0
 appVersion: 1.0.0

--- a/charts/app/templates/service.yaml
+++ b/charts/app/templates/service.yaml
@@ -6,7 +6,21 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     argocd.argoproj.io/sync-wave: "1"
+    {{- with .Values.network.annotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
+  type: {{ .Values.network.type | default "ClusterIP" }}
+  {{- with .Values.network.loadBalancerClass }}
+  loadBalancerClass: {{ . }}
+  {{- end }}
+  {{- with .Values.network.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.network.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ . }}
+  {{- end }}
   selector:
     app: {{ .Release.Name }}-app
     env: {{ .Values.environment }}

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -13,6 +13,7 @@ network:
   port: 2000
   containerTargetPort: 8000
   serviceEnabled: false
+  annotations: {}
 
 ingress:
   enabled: false


### PR DESCRIPTION
Promotes the merged develop branch to main, triggering chart-releaser to publish `app-2.12.0` to GH Pages.

Includes:
- **#128** — Service template supports `type: LoadBalancer` + `loadBalancerClass` + `loadBalancerSourceRanges` + `externalTrafficPolicy` + `network.annotations`. Backward compatible (defaults preserve ClusterIP).

Chart version: `2.11.1` → `2.12.0` (MINOR — additive opt-in surface, no breaking changes).

## Verify publish after merge

```bash
curl -s https://zimran-tech.github.io/helm-charts/index.yaml | grep "version: 2.12.0"
```