### PR TITLE
feat(app): add ServiceAccount and RoleBinding templates (opt-in)

### DIFF
--- a/charts/app/Chart.yaml
+++ b/charts/app/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: app
 description: A Helm chart for Prosperi Applications
 type: application
-version: 2.12.0
+version: 2.13.0
 appVersion: 1.0.0

--- a/charts/app/templates/rolebinding.yaml
+++ b/charts/app/templates/rolebinding.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.serviceAccount.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Values.serviceAccount.name }}-{{ .Values.serviceAccount.rbac.roleRef }}
+  namespace: {{ $.Release.Namespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.serviceAccount.name }}
+    namespace: {{ $.Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ .Values.serviceAccount.rbac.roleRef }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/app/templates/service-account.yaml
+++ b/charts/app/templates/service-account.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount.name }}
+  namespace: {{ $.Release.Namespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+    {{- with .Values.serviceAccount.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -52,8 +52,18 @@ ingress:
     issuer: https://zimran.okta.com
 
 serviceAccount:
+  # Set create: true to have the chart render the ServiceAccount object.
+  # Default false preserves prior behaviour where the SA was managed externally
+  # (Terraform module for cluster-infra SAs, or pre-existing in the cluster).
+  create: false
   name: secrets-csi-sa
-  annotations: { eks.amazonaws.com/role-arn: arn:aws:iam::account_id:role/role_name }
+  annotations: {}
+  rbac:
+    # Set rbac.create: true to render a RoleBinding (namespace-scoped) that
+    # binds the SA to an existing ClusterRole. Default false.
+    create: false
+    # ClusterRole to reference in the RoleBinding (e.g. built-in "view").
+    roleRef: view
 
 apps:
   - name: app


### PR DESCRIPTION
Adds two new templates to the `app` chart, both opt-in via flags with `false` defaults: `service-account.yaml` (gated by `serviceAccount.create`) and `rolebinding.yaml` (gated by `serviceAccount.rbac.create`). Backward compatible — services that don't set the flags render identically to before.

Enables IRSA workloads (cc-duty-agent in particular) to declare their SA + namespace-scoped RoleBinding via helm-values instead of as raw YAML applied separately. Matches the Helm best-practice pattern ([Helm docs — RBAC](https://helm.sh/docs/chart_best_practices/rbac/)) used by Bitnami, kube-prometheus-stack, and the official [aws-load-balancer-controller](https://github.com/kubernetes-sigs/aws-load-balancer-controller/tree/main/helm/aws-load-balancer-controller) chart.

The previous `service-account.yaml` template (removed in #92) used `helm lookup` which returns nil under ArgoCD's render path — see [argo-cd#5202](https://github.com/argoproj/argo-cd/issues/5202), open since 2021. The new template avoids `lookup` entirely; declarative opt-in flag replaces runtime discovery, so the rendered output is identical under `helm install`, `helm template`, and ArgoCD.

Chart version bumped 2.12.0 → 2.13.0.

## Example consumer (cc-duty-agent helm-values)

\`\`\`yaml
serviceAccount:
  create: true
  name: cc-duty-agent
  annotations:
    eks.amazonaws.com/role-arn: arn:aws:iam::ACCT:role/cc-duty-agent-production
    eks.amazonaws.com/sts-regional-endpoints: \"true\"
  rbac:
    create: true
    roleRef: view
\`\`\`

Renders a ServiceAccount + RoleBinding bound to the built-in \`view\` ClusterRole, scoped to the release namespace.

## Test plan

- [ ] \`helm template charts/app\` (no flags set) → no SA or RB rendered
- [ ] \`helm template charts/app --set serviceAccount.create=true\` → SA rendered
- [ ] \`helm template charts/app --set serviceAccount.create=true --set serviceAccount.rbac.create=true\` → SA + RB rendered
- [ ] Downstream rollout via [pivex-tech/tf-eks-pivex#62](https://github.com/pivex-tech/tf-eks-pivex/pull/62)